### PR TITLE
Add targeted but - ability to grab a specific argument index from callbacks

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
-module.exports = function (fn) {
+module.exports = function (fn, targetIndex) {
   return function (first) {
-    return fn(first);
+    if (typeof targetIndex !== 'number') return fn(first);
+    return fn(arguments[targetIndex]);
   };
 };

--- a/readme.markdown
+++ b/readme.markdown
@@ -78,6 +78,29 @@ async.waterfall([
 ])
 ```
 
+## Targeted but
+
+Need to zone in and grab just a specific argument from a callback? Targeted `but` to the rescue.
+
+`but(callback, targetIndex)`
+
+This way you can pass callbacks and grab any given target index of the callback (and not just the first):
+
+##### Before
+
+```js
+// get an index array
+n.map(function (val, index) {
+  return parseInt(index);
+});
+```
+
+##### After
+
+```js
+n.map(but(parseInt, 1));
+```
+
 # Why?
 
 It had to be done. It is known.

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@
 var assert = require('assert');
 var but = require('./');
 var n = [1, 2, 3, 4, 5];
+var s = ['a', 'b', 'c', 'd', 'e'];
 
 describe('a plain callback', function() {
   var nMappedPlain = n.map(parseInt);
@@ -16,4 +17,18 @@ describe('a but callback', function() {
     var nMappedAwesome = n.map(but(parseInt));
     assert(!isNaN(nMappedAwesome.pop()));
   })
+});
+
+describe('a targeted callback', function() {
+  it('fails with normal but', function() {
+    var nMappedAwesome = s.map(but(parseInt));
+    assert(isNaN(nMappedAwesome.pop()));
+  });
+
+  it('is amazing with targeted but', function() {
+    var nMappedAwesome = s.map(but(parseInt, 1));
+    var item = nMappedAwesome.shift();
+    assert(!isNaN(item));
+    assert(item === 0);
+  });
 });


### PR DESCRIPTION
Instead of forcing user to always use the first index argument of callbacks, he has ability to have a `targeted but` where he can choose which argument to use.

Can have multiple use cases:
- Get an index array (from map)
- Infinity and beyond with weird functions where you need a specific non-first argument

Use with `but(fn, targetIndex)`. If `targetIndex` isn't supplied or isn't a number - `but` behaves normally and uses the first argument.

Added test case, readme info and improved the src of `but`

_//TODO: support negative targetIndexes FTW!_
